### PR TITLE
Avoid overwriting previous config

### DIFF
--- a/tasks/chrome_extension_reload.js
+++ b/tasks/chrome_extension_reload.js
@@ -13,7 +13,7 @@ module.exports = function(grunt) {
   var chromeExtensionTabId = 0;
 
 
-  grunt.initConfig({
+  grunt.config.merge({
 
     /**
       Reloads tab in chrome with id of chromeExtensionTabId


### PR DESCRIPTION
grunt.initConfig overwrites previous configuration that the user's grunt file may have set up. Using grunt.config.merge instead of grunt.initConfig sets the config without overwriting previously-set configuration.
